### PR TITLE
add option to use --signoff with git commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Add a step like this to your workflow:
     # Default: false
     force: true
 
+    # Whether to use the --signoff option on `git commit`
+    # Default: false
+    signoff: true
+
     # The message for the commit
     # Default: 'Commit from GitHub Actions'
     message: 'Your commit message'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Whether to use the force option on git add, in order to bypass eventual gitignores
     required: false
     default: "false"
+  signoff:
+    description: Whether to use the signoff option on git commit
+    required: false
+    default: "false"
   message:
     description: The message for the commit
     required: false

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -70,7 +70,11 @@ if ! git diff --cached --quiet --exit-code; then
     remove
 
     echo "Creating commit..."
-    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>"
+    signoffcmd=
+    if $INPUT_SIGNOFF; then
+        signoffcmd=--signoff
+    fi
+    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" "$signoffcmd"
 
     echo "Tagging commit..."
     tag

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -31,6 +31,11 @@ remove() {
     if [ -n "$INPUT_REMOVE" ]; then git rm $INPUT_REMOVE; fi
 }
 
+commit() {
+    if $INPUT_SIGNOFF; then signoffcmd=--signoff; else signoffcmd=; fi
+    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" $signoffcmd
+}
+
 tag() {
     if [ -n "$INPUT_TAG" ]; then git tag $INPUT_TAG; fi
 }
@@ -70,11 +75,7 @@ if ! git diff --cached --quiet --exit-code; then
     remove
 
     echo "Creating commit..."
-    signoffcmd=
-    if $INPUT_SIGNOFF; then
-        signoffcmd=--signoff
-    fi
-    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" "$signoffcmd"
+    commit
 
     echo "Tagging commit..."
     tag

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -70,7 +70,11 @@ if ! git diff --cached --quiet --exit-code; then
     remove
 
     echo "Creating commit..."
-    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>"
+    signoffcmd=
+    if $INPUT_SIGNOFF; then
+        signoffcmd=--signoff
+    fi
+    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" "$signoffcmd"
 
     echo "Tagging commit..."
     tag

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -31,6 +31,11 @@ remove() {
     if [ -n "$INPUT_REMOVE" ]; then git rm $INPUT_REMOVE; fi
 }
 
+commit() {
+    if $INPUT_SIGNOFF; then signoffcmd=--signoff; else signoffcmd=; fi
+    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" $signoffcmd
+}
+
 tag() {
     if [ -n "$INPUT_TAG" ]; then git tag $INPUT_TAG; fi
 }
@@ -70,11 +75,7 @@ if ! git diff --cached --quiet --exit-code; then
     remove
 
     echo "Creating commit..."
-    signoffcmd=
-    if $INPUT_SIGNOFF; then
-        signoffcmd=--signoff
-    fi
-    git commit -m "$INPUT_MESSAGE" --author="$INPUT_AUTHOR_NAME <$INPUT_AUTHOR_EMAIL>" "$signoffcmd"
+    commit
 
     echo "Tagging commit..."
     tag


### PR DESCRIPTION
This PR adds the ability to `--signoff` the created commit by introducing a new options `signoff`.