### PR TITLE
Add info on actions@github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Add a step like this to your workflow:
     committer_name: Committer Name
 
     # The email of the custom committer you want to use, if different from the author of the commit.
+    # If one uses actions@github.com, the icon of https://github.com/actions/ will be shown as committer in the GitHub ui.
     # Default: the email of the author (set with either author_email or default_author)
     committer_email: mail@example.com
 


### PR DESCRIPTION
I think, it would be nice to show how a nice actions icon can be shown.

Example:

![grafik](https://user-images.githubusercontent.com/1366654/130127959-a297c12d-9fb5-411e-86c1-46412f483c03.png)