### PR TITLE
ignore protected .github folder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ core.info(`Running in ${baseDir}`)
   } else core.info('> No files to remove.')
   
   // ignore protected .github folder that contains the workflow files
-  await remove(".github")
+  await remove(".github/workflows")
 
   core.info('> Checking for uncommitted changes in the git working tree...')
   const changedFiles = (await git.diffSummary(['--cached'])).files.length


### PR DESCRIPTION
trying to push the .github folder results in a very undescriptive error on githubs end, so this pr just ignores it all together

error from github (changed file is .github/workflows/main.yml):

![image](https://user-images.githubusercontent.com/68407783/154313799-6995c9eb-a8d5-4466-ab80-c1f04b75676b.png)
