### PR TITLE
Update action to run on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ outputs:
     description: Whether the action has pushed a tag.
 
 runs:
-  using: node12
+  using: node16
   main: lib/index.js
 
 branding:


### PR DESCRIPTION
See See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12