### PR TITLE
Add how to autodetect deleted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ You can also use JSON or YAML arrays (e.g. `'["first", "second"]'`, `"['first', 
 
 ### Deleting files
 
-You can delete files with the `remove` option: that runs a `git rm` command that will stage the files in the given path for removal. As with the `add` argument, you can use every option `git rm` allows (e.g. add `--force` to ignore `.gitignore` rules).  
-The script will not stop if one of the git commands doesn't match any file. E.g.: if your command shows a "fatal: pathspec 'yourFile' did not match any files" error the action will go on.  
-You can also use JSON or YAML arrays (e.g. `'["first", "second"]'`, `"['first', 'second']"`) to make the action run multiple `git rm` commands: the action will log how your input has been parsed. Please mind that your input still needs to be a string because of how GitHub Actions works with inputs: just write your array inside the string, the action will parse it later.
+The `remove` option can be used if a predetermined list of files needs to be removed. The `remove` option runs `git rm`
+ command with any options passed into the `remove` setting.
+ 
+If instead you want deleted files to be autodetected and committed, you can use existing git support for that feature. `git add` supports the [`--no-ignore-removal`/`-A`](https://git-scm.com/docs/git-add#Documentation/git-add.txt--A) option which will detect deleted files just as it detects modified files. To use this ability, prepend `--no-ignore-removal` to the `add` option.
 
 ### Pushing
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,9 @@ You can also use JSON or YAML arrays (e.g. `'["first", "second"]'`, `"['first', 
 
 ### Deleting files
 
-The `remove` option can be used if a predetermined list of files needs to be removed. The `remove` option runs `git rm`
- command with any options passed into the `remove` setting.
+The `remove` option can be used if a predetermined list of files needs to be removed. It runs the `git rm` command, so you can pass every kind of argument with it. As if with the [`add` input](#adding-files), you can also use JSON or YAML arrays to make the action run multiple `git rm` commands.
  
-If instead you want deleted files to be autodetected and committed, you can use existing git support for that feature. `git add` supports the [`--no-ignore-removal`/`-A`](https://git-scm.com/docs/git-add#Documentation/git-add.txt--A) option which will detect deleted files just as it detects modified files. To use this ability, prepend `--no-ignore-removal` to the `add` option.
+If you want deleted files to be auto-detected and committed, you can use the [`--no-ignore-removal`/`-A`](https://git-scm.com/docs/git-add#Documentation/git-add.txt--A) git arguments.
 
 ### Pushing
 


### PR DESCRIPTION
The existing instructions make sense for when a predetermined list of files need to be removed. This is likely not a common use case so I shortened that explanation.  Also added the explanation on how to use `--no-ignore-removal` as the `add` setting to have deleted files autodetected.

Fixes #467