### PR TITLE
ci: pin actions-tagger and restrict release workflow permissions

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -4,10 +4,13 @@ on:
   release:
     types: [published, edited]
 
+permissions:
+  contents: write
+
 jobs:
   actions-tagger:
     runs-on: windows-2022
     steps:
-      - uses: Actions-R-Us/actions-tagger@v2
+      - uses: Actions-R-Us/actions-tagger@330ddfac760021349fef7ff62b372f2f691c20fb # v2.0.3
         with:
           publish_latest_tag: true


### PR DESCRIPTION
## Summary
- Pin `Actions-R-Us/actions-tagger` to commit SHA `330ddfac` (`v2.0.3`) instead of the mutable `@v2` tag.
- Add an explicit `permissions: contents: write` block so the release tag-update job only gets the scope it needs.

## Test plan
- [ ] Confirm `.github/workflows/versioning.yml` uses the pinned SHA and `permissions: contents: write`
- [ ] On the next published/edited release, verify major/`latest` tags still update as before