### PR TITLE
fix: Remove GH var interpolation in action.yml docstring

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: The email of the custom committer you want to use
     required: false
   cwd:
-    description: The directory where your repository is located (relative to the runner workspace, or an absolute path). You should use actions/checkout first to set it up. In with:, use ${{ github.workspace }} — $GITHUB_WORKSPACE is not expanded.
+    description: ${{ 'The directory where your repository is located (relative to the runner workspace, or an absolute path). You should use actions/checkout first to set it up. In with:, use ${{ github.workspace }} — $GITHUB_WORKSPACE is not expanded.' }}
     required: false
     default: '.'
   default_author:

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: The email of the custom committer you want to use
     required: false
   cwd:
-    description: ${{ 'The directory where your repository is located (relative to the runner workspace, or an absolute path). You should use actions/checkout first to set it up. In with:, use ${{ github.workspace }} — $GITHUB_WORKSPACE is not expanded.' }}
+    description: The directory where your repository is located (relative to the runner workspace, or an absolute path). You should use actions/checkout first to set it up. In with:, use the github.workspace context (see README) — $GITHUB_WORKSPACE is not expanded.
     required: false
     default: '.'
   default_author:


### PR DESCRIPTION
Fix for https://github.com/EndBug/add-and-commit/issues/782. This removes the unintentional GH variable interpolation from a docstring that was causing the action parsing to fail at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `cwd` input description by referencing the `github.workspace` context and README for usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->